### PR TITLE
Rework goto renumbering

### DIFF
--- a/LineChanger.py
+++ b/LineChanger.py
@@ -111,7 +111,7 @@ class AdjustSomeLineNumsCommand(sublime_plugin.TextCommand):
 			# popup warning if requested renumbering parameters will exceed max
 			self.view.show_popup('<h3>Renumbering Error!</h3> \
 				<p>Renumbering Start:Increment puts lines out of range. \
-				The maximum allowed line number is <strong>99999</strong>.</p>',
+				The maximum allowed line number is <strong>32767</strong>.</p>',
 				sublime.HIDE_ON_MOUSE_MOVE_AWAY,
 				max_width=1000,
 				max_height=500)

--- a/LineChanger.py
+++ b/LineChanger.py
@@ -93,7 +93,7 @@ class AdjustSomeLineNumsCommand(sublime_plugin.TextCommand):
 		start_pos, end_pos, lineCount = self.get_region()
 
 		# check whether requested renumbering values will exceed PPCL max
-		if (lineCount * adjust_line_increment + adjust_line_start - adjust_line_increment) < 100000:
+		if (lineCount * adjust_line_increment + adjust_line_start - adjust_line_increment) <= 32767:
 			selected_content = self.view.substr(sublime.Region(start_pos, end_pos))
 			full_content = self.view.substr(sublime.Region(0, self.view.size()))
 


### PR DESCRIPTION
1.	Added: Verify renumbered lines will not exceed the PPCL max of 99999, and display warning if invalid attempt is made.
2.	Changed: `GOs/ONs` in the entire file, not just the selection, are now renumbered if they point to lines being renumbered.
3.	Changed: When `GOs/ONs` point to nonexistent lines and a `GO_should` value **is** returned, the `GO_should` suggestion is now followed by `[suggested number]` (e.g. `GOTO 252[suggested number]`). This intentionally fails to compile in order to draw attention to the change/error. 
4.	Changed: When `GOs/ONs` point to nonexistent lines and a `GO_should` value is **not** returned, the original number is now wrapped with an error in square brackets (e.g. `GOTO [4000 Not Found]`. This intentionally fails to compile in order to draw attention to the change/error. 

I apologize for making too many changes in one pull request, but I couldn't figure out a good way to separate most of them because they are fairly interdependent. I started to try to break the changes down to make more granular requests, but I decided to just submit it and let you share your thoughts first.
I think it is critical that every missing or adjusted line number in `GOs/ONs` force a review by the programmer because program execution can be dramatically effected by a `GOTO` being off by even a single line. (This is the reasoning behind 3 & 4 above.)
In order to replace the `GOs/ONs` in the entire program, I restructured renumbering to:
1.	Capture the entire program ->
2.	Capture the selection (if only a portion is being renumbered) ->
2.	Replace line numbers in selection ->
2.	Replace the section of the entire program (captured in step 1) being renumber with the renumbered lines ->
3.	Process the `GOs/ONs` throughout the entire program