### PR TITLE
Report highlighting

### DIFF
--- a/ppcl.YAML-tmLanguage
+++ b/ppcl.YAML-tmLanguage
@@ -1,4 +1,4 @@
-# Copyright 2017 Brieb Blandford
+# Copyright 2017 Brien Blandford
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -84,6 +84,16 @@ patterns:
   begin: /\*
   end: \*/
 
+- comment: PPCL Report - find failed or unresolved lines
+  name: invalid.illegal.PPCL
+  begin: (^(E|D).{,2}(U|F))
+  end: (?=^E)
+
+- comment: PPCL Report - Make untraced or disabled lines, including line numbers, comments.
+  name: comment.block.PPCL
+  begin: (^(E|D)\s{5})
+  end: (?=^ET)
+
 - name: comment.block.PPCL
   begin: ([0-9]{5}([ ]{2,}|\t)(C|c))
   end: ($\n)
@@ -142,7 +152,7 @@ patterns:
     # '2': {name: support.constant.PPCL}
     '2': {name: punctuation.separator.parameters.ppcl}
     
-- comment: capture point names and make the orange and italic
+- comment: capture point names and make them orange and italic
   name: support.other.PPCL
   begin: (\")
   end: (\")

--- a/ppcl.tmLanguage
+++ b/ppcl.tmLanguage
@@ -154,6 +154,26 @@
 		</dict>
 		<dict>
 			<key>begin</key>
+			<string>(^(E|D).{,2}(U|F))</string>
+			<key>comment</key>
+			<string>PPCL Report - find failed or unresolved lines</string>
+			<key>end</key>
+			<string>(?=^E)</string>
+			<key>name</key>
+			<string>invalid.illegal.PPCL</string>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>(^(E|D)\s{5})</string>
+			<key>comment</key>
+			<string>PPCL Report - Make untraced or disabled lines, including line numbers, comments.</string>
+			<key>end</key>
+			<string>(?=^ET)</string>
+			<key>name</key>
+			<string>comment.block.PPCL</string>
+		</dict>
+		<dict>
+			<key>begin</key>
 			<string>([0-9]{5}([ ]{2,}|\t)(C|c))</string>
 			<key>end</key>
 			<string>($\n)</string>
@@ -296,7 +316,7 @@
 			<key>begin</key>
 			<string>(\")</string>
 			<key>comment</key>
-			<string>capture point names and make the orange and italic</string>
+			<string>capture point names and make them orange and italic</string>
 			<key>end</key>
 			<string>(\")</string>
 			<key>name</key>


### PR DESCRIPTION
Added syntax highlighting rules so Insight PPCL reports are highlighted correctly. 

- Untraced and disabled lines are grayed out like comments.
-  Failed and unresolved lines are marked as errors to draw attention.

![ppcl report highlighting example](https://user-images.githubusercontent.com/13118282/53369443-38b71900-3919-11e9-9038-cadbdebcf999.PNG)
