### PR TITLE
Insert line fix

### DIFF
--- a/LineChanger.py
+++ b/LineChanger.py
@@ -425,7 +425,7 @@ class InsertLinesCommand(sublime_plugin.TextCommand):
 
         if ((int(newLineNum) < int(nextLineNum)) or
                 (self.view.rowcol(self.view.size())[0] == row-1)):
-            self.view.insert(edit, self.view.line(self.view.sel()[0]).end(),
+            self.view.insert(edit, self.view.sel()[0].begin(),
                             '\n'+str(newLineNum)+'\t')
         else:
             # popup warning if auto-increment fails


### PR DESCRIPTION
This fixes a bug in the current behavior of the insert_line command, which intercepts the `enter` key.
If the  `enter` key is pressed at the beginning of a line of code, a new line is inserted below, but the code and cursor stays on the current line, and subsequent presses trigger an auto-increment warning.
Bug:
![ppcl insert line bug](https://user-images.githubusercontent.com/13118282/53514527-eea77200-3a95-11e9-8d08-68a5f0be78cc.gif)

Fix:
![ppcl insert line fix](https://user-images.githubusercontent.com/13118282/53514666-34fcd100-3a96-11e9-8bb2-18fafd0809aa.gif)
